### PR TITLE
chore: extract visitorHelper in rules/no-empty-url.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 lib
 coverage
+package-lock.json

--- a/rules/no-empty-url.js
+++ b/rules/no-empty-url.js
@@ -1,6 +1,25 @@
 const { Plugin } = require('ast-plugin');
 
 /**
+ * @param ast 传入的 ast
+ * @param text 抛错信息
+ */
+const visitorHelper = (ast, text) => {
+  const { url, value } = ast.node;
+
+  const line = ast.node.position.start.line;
+  const column = ast.node.position.start.column;
+
+  if (!url) {
+    this.cfg.throwError({
+      line,
+      column,
+      text
+    });
+  }
+};
+
+/**
  * link image 中地址不能为空
  * no-empty-url
  */
@@ -15,32 +34,10 @@ module.exports = class extends Plugin {
   visitor() {
     return {
       link: ast => {
-        const { url, value } = ast.node;
-
-        const line = ast.node.position.start.line;
-        const column = ast.node.position.start.column;
-
-        if (!url) {
-          this.cfg.throwError({
-            line,
-            column,
-            text: 'Link url can not be empty',
-          });
-        }
+        visitorHelper(ast, 'Link url can not be empty');
       },
       image: ast => {
-        const { url, value } = ast.node;
-
-        const line = ast.node.position.start.line;
-        const column = ast.node.position.start.column;
-
-        if (!url) {
-          this.cfg.throwError({
-            line,
-            column,
-            text: 'Image url can not be empty',
-          });
-        }
+        visitorHelper(ast, 'Image url can not be empty');
       },
     }
   }


### PR DESCRIPTION
Extract visitorHelper in rules/no-empty-url.js and reduce duplicated codebase.

Add package-lock.json into .gitignore