### PR TITLE
chore: extract visitorHelper in rules/no-empty-url.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 lib
 coverage
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ __tests__
 node_modules
 coverage
 tests
+package-lock.json

--- a/rules/helper/rule.js
+++ b/rules/helper/rule.js
@@ -1,6 +1,5 @@
 // 映射关系
 exports.ruleToLevel = rule => {
   return rule === 0 ? 'info' :
-    rule === 1 ? 'warning' :
-      rule === 2 ? 'error' : 'error';
+    rule === 1 ? 'warning' : 'error';
 };

--- a/rules/no-empty-url.js
+++ b/rules/no-empty-url.js
@@ -12,36 +12,25 @@ module.exports = class extends Plugin {
 
   pre() {}
 
+  emptyUrl(ast, text) {
+    const { url, value } = ast.node;
+
+    const line = ast.node.position.start.line;
+    const column = ast.node.position.start.column;
+
+    if (!url) {
+      this.cfg.throwError({
+        line,
+        column,
+        text
+      });
+    }
+  }
+
   visitor() {
     return {
-      link: ast => {
-        const { url, value } = ast.node;
-
-        const line = ast.node.position.start.line;
-        const column = ast.node.position.start.column;
-
-        if (!url) {
-          this.cfg.throwError({
-            line,
-            column,
-            text: 'Link url can not be empty',
-          });
-        }
-      },
-      image: ast => {
-        const { url, value } = ast.node;
-
-        const line = ast.node.position.start.line;
-        const column = ast.node.position.start.column;
-
-        if (!url) {
-          this.cfg.throwError({
-            line,
-            column,
-            text: 'Image url can not be empty',
-          });
-        }
-      },
+      link: ast => this.emptyUrl(ast, 'Link url can not be empty'),
+      image: ast => this.emptyUrl(ast, 'Image url can not be empty')
     }
   }
 


### PR DESCRIPTION
Extract visitorHelper in rules/no-empty-url.js and reduce duplicated codebase.

Add package-lock.json into .gitignore