### PR TITLE
rule: no-long-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ lint-md README.md Document.md --fix
 
 `no-long-code` 接受两个可配置参数：
 
-+ `length`: 每行代码接受的最大长度，默认值为 `100`
-+ `exclude`: 可以配置部分代码类型不做长度检查，默认值为 `[]`
++ `length`: 每行代码接受的最大长度，数字，默认值为 `100`
++ `exclude`: 可以配置部分代码类型不做长度检查，字符串数组，默认值为 `[]`
 
 ### Pull Request
 

--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ lint-md README.md Document.md --fix
 
 > 检查规则来源于 [chinese-document-style-guide](https://github.com/ruanyf/document-style-guide).
 
-| 规则 | 详细描述 | 解决办法 | 配置选项 |
-| ------ | ------ | ------ | ----- |
-| space-round-alphabet | 中文与英文之间需要增加空格 | 对应提示的位置增加空格 | |
-| space-round-number | 中文与数字之间需要增加空格 | 对应提示的位置增加空格 | |
-| no-empty-code-lang | 代码语言不能为空 | 在代码块语法上增加语言 | |
-| no-empty-delete | delete 块内容不能为空 | 删除空的 delete 文本块 | |
-| no-empty-url | 链接和图片地址不能为空 | 填写完整的 url，或者不使用链接和图片语法 | |
-| no-empty-list | List 内容不能为空 | List 语法中，填写内容 | |
-| no-empty-code | 代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | |
-| no-empty-inlinecode | 行内代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | |
-| no-empty-blockquote | blockquote 内容不能为空 | 删除空的 blockquote，或者填充内容 | |
-| no-special-characters | 文本中不能有特殊字符 | 可能是复制出来的特殊字符，删除特殊字符即可 | |
-| use-standard-ellipsis | 使用标准规范的省略号 | 使用标准规范的省略号‘……’ / ‘...’ | |
-| no-fullwidth-number | 不能用全角数字 | 注意输入法切换为半角输入 | |
-| no-space-in-emphasis | emphasis 内容前后不能有空格 | 删除 emphasis 内容中的前后空格即可 | |
-| no-space-in-link | link 内容前后不能有空格 | 删除 link 内容中的前后空格即可 | |
-| no-multiple-space-blockquote | blockquote 语法不能包含有多个空格 | 删除 blockquote 内容中多余的空格 | |
-| no-trailing-punctuation | 标题不能以标点符号结尾 | 删除标题最后的标点符号 | |
-| no-space-in-inlinecode | 行内代码内容，前后不能有空格 | 删除行内代码中的前后空格 | |
-| no-long-code | 代码块不能有过长的代码 | 对展示代码做格式上的修改 | `length`, `exclude` （见下文说明） |
+| 规则 | 详细描述 | 解决办法 | 配置选项 | 自动修复 |
+| ------ | ------ | ------ | ----- | ----- |
+| space-round-alphabet | 中文与英文之间需要增加空格 | 对应提示的位置增加空格 | | √ |
+| space-round-number | 中文与数字之间需要增加空格 | 对应提示的位置增加空格 | | √ |
+| no-empty-code-lang | 代码语言不能为空 | 在代码块语法上增加语言 | | √ |
+| no-empty-delete | delete 块内容不能为空 | 删除空的 delete 文本块 | | √ |
+| no-empty-url | 链接和图片地址不能为空 | 填写完整的 url，或者不使用链接和图片语法 | | √ |
+| no-empty-list | List 内容不能为空 | List 语法中，填写内容 | | √ |
+| no-empty-code | 代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | | √ |
+| no-empty-inlinecode | 行内代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | | √ |
+| no-empty-blockquote | blockquote 内容不能为空 | 删除空的 blockquote，或者填充内容 | | √ |
+| no-special-characters | 文本中不能有特殊字符 | 可能是复制出来的特殊字符，删除特殊字符即可 | | √ |
+| use-standard-ellipsis | 使用标准规范的省略号 | 使用标准规范的省略号‘……’ / ‘...’ | | √ |
+| no-fullwidth-number | 不能用全角数字 | 注意输入法切换为半角输入 | | √ |
+| no-space-in-emphasis | emphasis 内容前后不能有空格 | 删除 emphasis 内容中的前后空格即可 | | √ |
+| no-space-in-link | link 内容前后不能有空格 | 删除 link 内容中的前后空格即可 | | √ |
+| no-multiple-space-blockquote | blockquote 语法不能包含有多个空格 | 删除 blockquote 内容中多余的空格 | | √ |
+| no-trailing-punctuation | 标题不能以标点符号结尾 | 删除标题最后的标点符号 | | √ |
+| no-space-in-inlinecode | 行内代码内容，前后不能有空格 | 删除行内代码中的前后空格 | | √ |
+| no-long-code | 代码块不能有过长的代码 | 对展示代码做格式上的修改 | `length`, `exclude` （见下文说明） | x |
 
 ### 配置选项
 

--- a/README.md
+++ b/README.md
@@ -49,26 +49,35 @@ lint-md README.md Document.md --fix
 
 > 检查规则来源于 [chinese-document-style-guide](https://github.com/ruanyf/document-style-guide).
 
-| 规则 | 详细描述 | 解决办法 |
-| ------ | ------ | ------ |
-| space-round-alphabet | 中文与英文之间需要增加空格 | 对应提示的位置增加空格 |
-| space-round-number | 中文与数字之间需要增加空格 | 对应提示的位置增加空格 |
-| no-empty-code-lang | 代码语言不能为空 | 在代码块语法上增加语言 |
-| no-empty-delete | delete 块内容不能为空 | 删除空的 delete 文本块 |
-| no-empty-url | 链接和图片地址不能为空 | 填写完整的 url，或者不使用链接和图片语法 |
-| no-empty-list | List 内容不能为空 | List 语法中，填写内容 |
-| no-empty-code | 代码块内容不能为空 | 删除空的代码块，或者填充代码内容 |
-| no-empty-inlinecode | 行内代码块内容不能为空 | 删除空的代码块，或者填充代码内容 |
-| no-empty-blockquote | blockquote 内容不能为空 | 删除空的 blockquote，或者填充内容 |
-| no-special-characters | 文本中不能有特殊字符 | 可能是复制出来的特殊字符，删除特殊字符即可 |
-| use-standard-ellipsis | 使用标准规范的省略号 | 使用标准规范的省略号‘……’ / ‘...’ |
-| no-fullwidth-number | 不能用全角数字 | 注意输入法切换为半角输入 |
-| no-space-in-emphasis | emphasis 内容前后不能有空格 | 删除 emphasis 内容中的前后空格即可 |
-| no-space-in-link | link 内容前后不能有空格 | 删除 link 内容中的前后空格即可 |
-| no-multiple-space-blockquote | blockquote 语法不能包含有多个空格 | 删除 blockquote 内容中多余的空格 |
-| no-trailing-punctuation | 标题不能以标点符号结尾 | 删除标题最后的标点符号 |
-| no-space-in-inlinecode | 行内代码内容，前后不能有空格 | 删除行内代码中的前后空格 |
+| 规则 | 详细描述 | 解决办法 | 配置选项 |
+| ------ | ------ | ------ | ----- |
+| space-round-alphabet | 中文与英文之间需要增加空格 | 对应提示的位置增加空格 | |
+| space-round-number | 中文与数字之间需要增加空格 | 对应提示的位置增加空格 | |
+| no-empty-code-lang | 代码语言不能为空 | 在代码块语法上增加语言 | |
+| no-empty-delete | delete 块内容不能为空 | 删除空的 delete 文本块 | |
+| no-empty-url | 链接和图片地址不能为空 | 填写完整的 url，或者不使用链接和图片语法 | |
+| no-empty-list | List 内容不能为空 | List 语法中，填写内容 | |
+| no-empty-code | 代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | |
+| no-empty-inlinecode | 行内代码块内容不能为空 | 删除空的代码块，或者填充代码内容 | |
+| no-empty-blockquote | blockquote 内容不能为空 | 删除空的 blockquote，或者填充内容 | |
+| no-special-characters | 文本中不能有特殊字符 | 可能是复制出来的特殊字符，删除特殊字符即可 | |
+| use-standard-ellipsis | 使用标准规范的省略号 | 使用标准规范的省略号‘……’ / ‘...’ | |
+| no-fullwidth-number | 不能用全角数字 | 注意输入法切换为半角输入 | |
+| no-space-in-emphasis | emphasis 内容前后不能有空格 | 删除 emphasis 内容中的前后空格即可 | |
+| no-space-in-link | link 内容前后不能有空格 | 删除 link 内容中的前后空格即可 | |
+| no-multiple-space-blockquote | blockquote 语法不能包含有多个空格 | 删除 blockquote 内容中多余的空格 | |
+| no-trailing-punctuation | 标题不能以标点符号结尾 | 删除标题最后的标点符号 | |
+| no-space-in-inlinecode | 行内代码内容，前后不能有空格 | 删除行内代码中的前后空格 | |
+| no-long-code | 代码块不能有过长的代码 | 对展示代码做格式上的修改 | `length`, `exclude` （见下文说明） |
 
+### 配置选项
+
+`no-long-code` 接受两个可配置参数：
+
++ `length`: 每行代码接受的最大长度，默认值为 `100`
++ `exclude`: 可以配置部分代码类型不做长度检查，默认值为 `[]`
+
+### Pull Request
 
 > 目前仅仅检查了比较通用的类型，**欢迎 pull request**，在 `rules` 中增加自己的规则，开发约束：
 
@@ -88,16 +97,22 @@ lint-md README.md Document.md --fix
 {
   "excludeFiles": [],
   "rules": {
-    "no-empty-code": 1
+    "no-empty-code": 1,
+    "no-long-code": [2, {
+      "length": 100,
+      "exclude": ["dot"]
+    }]
   }
 }
 ```
 
-通过 rules 来配置规则的等级。
+通过 rules 来配置规则。`key` 对应规则的名称。如果 `value` 是一个数字，那么表示规则的等级：
 
  - **0**：ignore 忽略不检查该规则
  - **1**：warning 警告，但不阻断 ci
  - **2**：error 错误，且阻断 ci
+
+如果 `value` 是一个数组，那么第一个是数字，表示该规则的等级；第二个为规则可接受的配置信息。
 
 通过 excludeFiles 来忽略文件和目录，glob 语法。
 

--- a/__tests__/lint-rules/no-long-code.spec.js
+++ b/__tests__/lint-rules/no-long-code.spec.js
@@ -66,6 +66,51 @@ describe('no-long-code', () => {
     ]);
   });
 
+  test('fail on every long line', () => {
+    const code = 'console.log("hello world");';
+    const md = [
+      '```js',
+      code,
+      'short',
+      code,
+      'short',
+      '```',
+    ].join('\n');
+
+    expect(lint(md, {
+      'no-long-code': [2, {
+        length: 10,
+      }],
+    })).toEqual([
+      {
+        level: 'error',
+        start: {
+          line: 2,
+          column: 1,
+        },
+        end: {
+          line: 2,
+          column: code.length + 1,
+        },
+        text: `line with ${code.length} characters exceeds code max length 10`,
+        type: 'no-long-code',
+      },
+      {
+        level: 'error',
+        start: {
+          line: 4,
+          column: 1,
+        },
+        end: {
+          line: 4,
+          column: code.length + 1,
+        },
+        text: `line with ${code.length} characters exceeds code max length 10`,
+        type: 'no-long-code',
+      },
+    ]);
+  });
+
   test('success with exclude lang configured', () => {
     const longCode = 'console.log("very long long long long long long long long long long long long long sentence");';
     const md = [

--- a/__tests__/lint-rules/no-long-code.spec.js
+++ b/__tests__/lint-rules/no-long-code.spec.js
@@ -1,0 +1,83 @@
+import lint from '../lint';
+
+describe('no-long-code', () => {
+  test('success', () => {
+    const md = [
+      '```js',
+      'console.log("this is a short line");',
+      'console.log("with multiple lines");',
+      '```',
+    ].join('\n');
+
+    expect(lint(md)).toEqual([]);
+  });
+
+  test('fail', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
+    const md = [
+      '```js',
+      longCode,
+      '```',
+    ].join('\n');
+
+    expect(lint(md)).toEqual([
+      {
+        level: 'error',
+        start: {
+          line: 2,
+          column: 1,
+        },
+        end: {
+          line: 2,
+          column: longCode.length + 1,
+        },
+        text: `line with ${longCode.length} characters exceeds code max length 100`,
+        type: 'no-long-code'
+      }
+    ]);
+  });
+
+  test('fail with length configured', () => {
+    const code = 'console.log("hello world");';
+    const md = [
+      '```js',
+      code,
+      '```',
+    ].join('\n');
+
+    expect(lint(md, {
+      'no-long-code': [2, {
+        length: 10,
+      }],
+    })).toEqual([
+      {
+        level: 'error',
+        start: {
+          line: 2,
+          column: 1,
+        },
+        end: {
+          line: 2,
+          column: code.length + 1,
+        },
+        text: `line with ${code.length} characters exceeds code max length 10`,
+        type: 'no-long-code',
+      },
+    ]);
+  });
+
+  test('success with exclude lang configured', () => {
+    const longCode = 'console.log("very long long long long long long long long long long long long long sentence");';
+    const md = [
+      '```js',
+      longCode,
+      '```',
+    ].join('\n');
+
+    expect(lint(md, {
+      'no-long-code': [2, {
+        exclude: ['js'],
+      }],
+    })).toEqual([]);
+  });
+});

--- a/__tests__/lint-rules/no-long-code.spec.js
+++ b/__tests__/lint-rules/no-long-code.spec.js
@@ -112,7 +112,7 @@ describe('no-long-code', () => {
   });
 
   test('success with exclude lang configured', () => {
-    const longCode = 'console.log("very long long long long long long long long long long long long long sentence");';
+    const longCode = 'console.log("very long long long long long long long long long long long long long long long long long sentence");';
     const md = [
       '```js',
       longCode,

--- a/src/description/en_US.js
+++ b/src/description/en_US.js
@@ -49,5 +49,8 @@ export default {
   },
   'no-space-in-inlinecode': {
     message: 'Inline code content can not start / end with space.'
-  }
+  },
+  'no-long-code': {
+    message: 'Code Block cannot have too long line.',
+  },
 }

--- a/src/lint-rules/index.js
+++ b/src/lint-rules/index.js
@@ -31,21 +31,29 @@ const PluginClasses = [
  */
 export default (throwError, rules) => {
   // 所有的插件的默认 rules
-  const initialRules = {};
+  const rulesConfig = {};
 
   _.forEach(PluginClasses, Plugin => {
-    initialRules[Plugin.type] = 2; // 默认都是 error
+    rulesConfig[Plugin.type] = {
+      level: 2, // 默认都是 error
+    };
   });
 
   // 用 rules 覆盖初始配置
-  const rulesConfig = _.merge({}, initialRules, rules);
+  Object.keys(rules).forEach((rule) => {
+    const [level, config] = [].concat(rules[rule]);
+    rulesConfig[rule] = {
+      level,
+      config,
+    };
+  });
 
   // 配置为 0 的就是关闭，不启用插件！
-  const Plugins = _.filter(PluginClasses, Plugin => rulesConfig[Plugin.type] !== 0);
+  const Plugins = _.filter(PluginClasses, Plugin => rulesConfig[Plugin.type].level !== 0);
 
   // 初始化插件
   return _.map(Plugins, Plugin => {
-    const level = ruleToLevel(rulesConfig[Plugin.type]);
+    const level = ruleToLevel(rulesConfig[Plugin.type].level);
 
     // 重新包装一下 throw 方法，加入 level
     const throwErrorFunc = error => {
@@ -54,6 +62,6 @@ export default (throwError, rules) => {
       throwError(error);
     };
 
-    return new Plugin({ throwError: throwErrorFunc });
+    return new Plugin({ throwError: throwErrorFunc, config: rulesConfig[Plugin.type].config });
   });
 };

--- a/src/lint-rules/index.js
+++ b/src/lint-rules/index.js
@@ -19,6 +19,7 @@ const PluginClasses = [
   require('./no-multiple-space-blockquote'),
   require('./no-space-in-inlinecode'),
   require('./no-trailing-punctuation'),
+  require('./no-long-code'),
 ];
 
 

--- a/src/lint-rules/no-long-code.js
+++ b/src/lint-rules/no-long-code.js
@@ -1,5 +1,10 @@
 import { Plugin } from 'ast-plugin';
 
+const defaultConfig = {
+  length: 100,
+  excludes: [],
+};
+
 /**
  * 代码长度有限制
  * no-long-code
@@ -12,15 +17,13 @@ module.exports = class extends Plugin {
   pre() { }
 
   visitor() {
-    const { config = { } } = this.cfg;
-    const excludes = [].concat(config.exclude).filter(exclude => typeof exclude === 'string');
-    const length = typeof config.length === 'number' ? config.length : 100;
+    const config = Object.assign({}, defaultConfig, this.cfg.config);
     return {
       code: (ast) => {
         const { lang, value, position } = ast.node;
-        if (excludes.indexOf(lang) >= 0) return;
+        if (config.excludes.indexOf(lang) >= 0) return;
         value.split('\n').every((line, i) => {
-          const isTooLong = line.length > length;
+          const isTooLong = line.length > config.length;
           if (isTooLong) {
             const { start } = position;
             this.cfg.throwError({
@@ -32,7 +35,7 @@ module.exports = class extends Plugin {
                 line: start.line + i + 1,
                 column: line.length + 1,
               },
-              text: `line with ${line.length} characters exceeds code max length ${length}`,
+              text: `line with ${line.length} characters exceeds code max length ${config.length}`,
               ast,
             });
           }

--- a/src/lint-rules/no-long-code.js
+++ b/src/lint-rules/no-long-code.js
@@ -22,7 +22,7 @@ module.exports = class extends Plugin {
       code: (ast) => {
         const { lang, value, position } = ast.node;
         if (config.excludes.indexOf(lang) >= 0) return;
-        value.split('\n').every((line, i) => {
+        value.split('\n').forEach((line, i) => {
           const isTooLong = line.length > config.length;
           if (isTooLong) {
             const { start } = position;

--- a/src/lint-rules/no-long-code.js
+++ b/src/lint-rules/no-long-code.js
@@ -2,7 +2,7 @@ import { Plugin } from 'ast-plugin';
 
 const defaultConfig = {
   length: 100,
-  excludes: [],
+  exclude: [],
 };
 
 /**
@@ -21,7 +21,7 @@ module.exports = class extends Plugin {
     return {
       code: (ast) => {
         const { lang, value, position } = ast.node;
-        if (config.excludes.indexOf(lang) >= 0) return;
+        if (config.exclude.indexOf(lang) >= 0) return;
         value.split('\n').forEach((line, i) => {
           const isTooLong = line.length > config.length;
           if (isTooLong) {

--- a/src/lint-rules/no-long-code.js
+++ b/src/lint-rules/no-long-code.js
@@ -1,0 +1,46 @@
+import { Plugin } from 'ast-plugin';
+
+/**
+ * 代码长度有限制
+ * no-long-code
+ */
+module.exports = class extends Plugin {
+  static get type() {
+    return 'no-long-code';
+  }
+
+  pre() { }
+
+  visitor() {
+    const { config = { } } = this.cfg;
+    const excludes = [].concat(config.exclude).filter(exclude => typeof exclude === 'string');
+    const length = typeof config.length === 'number' ? config.length : 100;
+    return {
+      code: (ast) => {
+        const { lang, value, position } = ast.node;
+        if (excludes.indexOf(lang) >= 0) return;
+        value.split('\n').every((line, i) => {
+          const isTooLong = line.length > length;
+          if (isTooLong) {
+            const { start } = position;
+            this.cfg.throwError({
+              start: {
+                line: start.line + i + 1,
+                column: 1,
+              },
+              end: {
+                line: start.line + i + 1,
+                column: line.length + 1,
+              },
+              text: `line with ${line.length} characters exceeds code max length ${length}`,
+              ast,
+            });
+          }
+          return !isTooLong;
+        });
+      },
+    };
+  }
+
+  post() { }
+}


### PR DESCRIPTION
## bad

```javascript
for (const i = 0; i < array.length; i += 1) if (someConditionIsTrue) console.log('output something here');
```

## good

```javascript
for (const i = 0; i < array.length; i += 1) {
  if (someConditionIsTrue) {
    console.log('output something here');
  }
}
```

希望可以增加一个检查规则，在代码存在过长内容的时候报错。因为如果一行代码过长，在阅读体验上并不是非常好。

同时，为了能让这个最大长度可配置（适应不同情况下的阅读体验），配置的方式也做了调整。`rules` 除了可以给一个数字表示 level 之外，也可以给一个数组，其中第一个数字表示 level，第二个值是配置参数。（参考 `eslint` 的配置）

默认的最大长度是 100

另外，有些 code block 可能不是直接用于生成源码的（如，[gatsby-remark-graphviz](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-graphviz)），所以增加了 `exclude` 配置，可以不检查某些特定的代码类型。