### PR TITLE
修复Windows下无法使用通配符路径的错误

### DIFF
--- a/packages/lint-md-cli/src/helper/file.js
+++ b/packages/lint-md-cli/src/helper/file.js
@@ -20,10 +20,13 @@ module.exports = (src, config) => {
   const { excludeFiles } = config;
 
   return new Promise((resolve, reject) => {
-    const srcArr = Array.isArray(src) ? src : [src];
-
     setTimeout(() => {
       const files = [];
+      const srcArr = [];
+        
+      for (let i = 0; i < src.length; i ++) {
+        srcArr.push(...glob.sync(src[i]))
+      }
 
       for (let i = 0; i < srcArr.length; i ++) {
         let f = [];


### PR DESCRIPTION
Fixes #52 windows 下使用 npm/yarn 运行 lint-md 时参数会直接以字符串的形式传入，而直接运行 lint-md 或 Linux 环境下使用时含有通配符的路径会被 shell 展开后传入